### PR TITLE
Remove cancel on each command

### DIFF
--- a/client.go
+++ b/client.go
@@ -96,8 +96,7 @@ func (c *client) serve(conn net.Conn) error {
 			Out:     c,
 			TraceID: GenerateTraceID(),
 		}
-		innerCtx, cancel := context.WithCancel(rootCtx)
-		ctx.Context = innerCtx
+		ctx.Context = rootCtx
 
 		// Skip reply if necessary
 		if c.cliCtx.SkipN != 0 {
@@ -113,7 +112,6 @@ func (c *client) serve(conn net.Conn) error {
 				zap.String("command", ctx.Name))
 		}
 		c.exec.Execute(ctx)
-		cancel()
 	}
 }
 


### PR DESCRIPTION
Use the `rootContext` on each command execution to avoid the bugs of TiKV SDK.

There is a bug in TiKV SDK, the SDK commits the secondary batch of keys in the background with the context that the client supplied, when the context is canceled, the job will be aborted and then causes some secondary locks left on keys which should have been cleaned up.