### PR TITLE
Update tidb to the latest master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,24 +1,21 @@
 module github.com/meitu/titan
 
 require (
+	github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 // indirect
 	github.com/arthurkiller/rollingWriter v1.0.1
-	github.com/coreos/etcd v3.3.10+incompatible // indirect
+	github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292 // indirect
+	github.com/coreos/bbolt v1.3.1-coreos.6 // indirect
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect
 	github.com/cznic/sortutil v0.0.0-20181122101858-f5f958428db8 // indirect
 	github.com/facebookgo/grace v0.0.0-20180706040059-75cf19382434 // indirect
 	github.com/golang/protobuf v1.2.0
 	github.com/gomodule/redigo v2.0.0+incompatible
-	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
-	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5 // indirect
 	github.com/naoina/go-stringutil v0.1.0 // indirect
-	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e // indirect
-	github.com/pingcap/kvproto v0.0.0-20190108070055-434412f54395 // indirect
-	github.com/pingcap/tidb v2.1.2+incompatible
+	github.com/pingcap/tidb v0.0.0-20190118144702-443c103f4f1d
 	github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/prometheus/client_golang v0.9.2
-	github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446 // indirect
 	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/shafreeck/configo v0.0.0-20170612223031-a52cd6b0688a
@@ -26,12 +23,8 @@ require (
 	github.com/shafreeck/retry v0.0.0-20180827080527-71c8c3fbf8f8
 	github.com/shafreeck/toml v0.0.0-20160718194341-4ad33e231a16 // indirect
 	github.com/sirupsen/logrus v1.3.0
-	github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 // indirect
 	github.com/stretchr/testify v1.2.2
 	github.com/twinj/uuid v1.0.0
-	go.uber.org/atomic v1.3.2 // indirect
-	go.uber.org/multierr v1.1.0 // indirect
+	github.com/ugorji/go v1.1.1 // indirect
 	go.uber.org/zap v1.9.1
-	google.golang.org/grpc v1.17.0 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 )


### PR DESCRIPTION
Update TiKV SDK to the laster master to avoid memory leaks. Details: https://github.com/pingcap/tidb/pull/9121