### PR TITLE
Backoff TiKV SDK to release-2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,30 +1,75 @@
 module github.com/meitu/titan
 
 require (
-	github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 // indirect
+	github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f // indirect
 	github.com/arthurkiller/rollingWriter v1.0.1
-	github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292 // indirect
-	github.com/coreos/bbolt v1.3.1-coreos.6 // indirect
+	github.com/boltdb/bolt v1.3.1 // indirect
+	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
+	github.com/coreos/etcd v3.3.10+incompatible // indirect
+	github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142 // indirect
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect
 	github.com/cznic/sortutil v0.0.0-20181122101858-f5f958428db8 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/facebookgo/grace v0.0.0-20180706040059-75cf19382434 // indirect
+	github.com/go-ole/go-ole v1.2.1 // indirect
+	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/golang/protobuf v1.2.0
 	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/mux v1.6.2 // indirect
+	github.com/gorilla/websocket v1.4.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.5.1 // indirect
 	github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5 // indirect
+	github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5 // indirect
+	github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808 // indirect
+	github.com/myesui/uuid v1.0.0 // indirect
 	github.com/naoina/go-stringutil v0.1.0 // indirect
-	github.com/pingcap/tidb v0.0.0-20190118144702-443c103f4f1d
+	github.com/onsi/gomega v1.4.3 // indirect
+	github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8 // indirect
+	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e // indirect
+	github.com/pingcap/kvproto v0.0.0-20190110035000-d4fe6b336379 // indirect
+	github.com/pingcap/tidb v0.0.0-20190121074118-82eebf17ed8c
+	github.com/pingcap/tidb-tools v2.1.3-0.20190104033906-883b07a04a73+incompatible // indirect
 	github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/prometheus/client_golang v0.9.2
+	github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446 // indirect
 	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/shafreeck/configo v0.0.0-20170612223031-a52cd6b0688a
 	github.com/shafreeck/continuous v0.0.0-20181107093210-119a324e6bc5
 	github.com/shafreeck/retry v0.0.0-20180827080527-71c8c3fbf8f8
 	github.com/shafreeck/toml v0.0.0-20160718194341-4ad33e231a16 // indirect
+	github.com/shirou/gopsutil v2.18.10+incompatible // indirect
+	github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371 // indirect
+	github.com/shurcooL/vfsgen v0.0.0-20181020040650-a97a25d856ca // indirect
 	github.com/sirupsen/logrus v1.3.0
+	github.com/soheilhy/cmux v0.1.4 // indirect
+	github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 // indirect
 	github.com/stretchr/testify v1.2.2
+	github.com/struCoder/pidusage v0.1.2 // indirect
+	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 // indirect
+	github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6 // indirect
 	github.com/twinj/uuid v1.0.0
-	github.com/ugorji/go v1.1.1 // indirect
+	github.com/uber-go/atomic v1.3.2 // indirect
+	github.com/uber/jaeger-client-go v2.15.0+incompatible // indirect
+	github.com/uber/jaeger-lib v1.5.0 // indirect
+	github.com/ugorji/go/codec v0.0.0-20181127175209-856da096dbdf // indirect
+	github.com/unrolled/render v0.0.0-20180914162206-b9786414de4d // indirect
+	go.uber.org/atomic v1.3.2 // indirect
+	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1
+	golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e // indirect
+	golang.org/x/sys v0.0.0-20190109145017-48ac38b7c8cb // indirect
+	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
+	google.golang.org/genproto v0.0.0-20190108161440-ae2f86662275 // indirect
+	google.golang.org/grpc v1.17.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/stretchr/testify.v1 v1.2.2 // indirect
+	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4 // indirect
+	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67 // indirect
 )


### PR DESCRIPTION
 env GO111MODULE=on go get github.com/pingcap/tidb@release-2.1