### PR TITLE
fixed meta-slot  configuration item cannot be activated

### DIFF
--- a/db/hash.go
+++ b/db/hash.go
@@ -134,20 +134,6 @@ func hashItemKey(key []byte, field []byte) []byte {
 	return append(dkey, field...)
 }
 
-func (hash *Hash) calculateSlotID(limit int64) int64 {
-	if !hash.isMetaSlot() || limit <= 1 {
-		return 0
-	}
-	return rand.Int63n(limit - 1)
-}
-
-func (hash *Hash) isMetaSlot() bool {
-	if hash.meta.MetaSlot != 0 {
-		return true
-	}
-	return false
-}
-
 //SlotGC adds slotKey to GC remove queue
 func slotGC(txn *Transaction, objID []byte) error {
 	key := MetaSlotKey(txn.db, objID, nil)
@@ -720,9 +706,10 @@ func (hash *Hash) updateSlot(slotID int64, slot *Slot) error {
 }
 
 func (hash *Hash) getMetaSlotKeys() [][]byte {
-	metaSlot := hash.meta.MetaSlot
+	// meta slot id in [0,metaSlot)
+	metaSlot := hash.meta.MetaSlot - 1
 	keys := make([][]byte, metaSlot)
-	for metaSlot > 0 {
+	for metaSlot >= 0 {
 		keys = append(keys, MetaSlotKey(hash.txn.db, hash.meta.ID, EncodeInt64(metaSlot)))
 		metaSlot--
 	}

--- a/db/hash_test.go
+++ b/db/hash_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	defaultHashMetaSlot int64 = 0
+)
+
 // compareGetString skip CreatedAt UpdatedAt ID compare
 func compareGetHash(want, get *Hash) error {
 	switch {

--- a/db/hash_test.go
+++ b/db/hash_test.go
@@ -10,10 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	defaultHashMetaSlot int64 = 0
-)
-
 // compareGetString skip CreatedAt UpdatedAt ID compare
 func compareGetHash(want, get *Hash) error {
 	switch {
@@ -71,7 +67,7 @@ func Test_newHash(t *testing.T) {
 			want: &Hash{
 				meta: &HashMeta{
 					Len:      0,
-					MetaSlot: defaultHashMetaSlot,
+					MetaSlot: 0,
 				},
 				key: []byte("TestNewHash"),
 				txn: txn,
@@ -207,7 +203,7 @@ func TestGetHash(t *testing.T) {
 							Type: ObjectHash,
 						},
 						Len:      0,
-						MetaSlot: defaultHashMetaSlot,
+						MetaSlot: 0,
 					},
 					key:    []byte("TestGetHashNoExistKey"),
 					exists: false,
@@ -229,7 +225,7 @@ func TestGetHash(t *testing.T) {
 						Type: ObjectHash,
 					},
 					Len:      1,
-					MetaSlot: defaultHashMetaSlot,
+					MetaSlot: 0,
 				},
 					key:    []byte("TestGetHashExistKey"),
 					exists: true,


### PR DESCRIPTION
Old hash keys do not work when changing the titan.toml file meta-slot configuration item
